### PR TITLE
Fix hub['count'] error when json output is integer

### DIFF
--- a/save_data.py
+++ b/save_data.py
@@ -40,6 +40,7 @@ def main():
     destination = mtr_result['report']['mtr']['dst']
     report_time = dt.datetime.utcnow()
     for hub in mtr_result['report']['hubs']:
+        hub['count'] = str(hub['count'])
         # persist the hub entry
         # Modifying the data if needed so that is can be easily sorted in the event of more than 9 hops.
         if len(hub['count']) < 2:


### PR DESCRIPTION
MTR changed their json library sometime after v.92 and it creates the hub['count'] field as an integer instead of a string which breaks this script. Added a line to explicitly convert this value into a string to work with all versions of mtr.

Output in mtr v.92:
```
   "hubs": [{
      "count": "1",
      "host": "172.17.0.1",
      "Loss%": 0.00,
      "Snt": 10,
      "Last": 0.06,
      "Avg": 0.12,
      "Best": 0.06,
      "Wrst": 0.15,
      "StDev": 0.03
    },
```

Output in mtr v.95:
```
 "hubs": [
            {
                "count": 1,
                "host": "_gateway",
                "Loss%": 40.0,
                "Snt": 10,
                "Last": 0.296,
                "Avg": 0.288,
                "Best": 0.261,
                "Wrst": 0.3,
                "StDev": 0.014
            },
```